### PR TITLE
Add release-branch CI config for 3.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            3.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds the `releaseBranch:` block to the build-and-publish step so the 3.x maintenance branch can publish XP 7 patch releases alongside master.

This is the maintenance-branch counterpart to the XP 8 upgrade PR on `master` — see app-booster's master/1.x split for the pattern.

No code changes; CI config only. `xpVersion=7.0.0` and `version=3.0.2-SNAPSHOT` on `3.x` are intentionally untouched (XP 7 maintenance state).