### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'com.enonic.lib:lib-http-client:4.0.0-SNAPSHOT'
+    implementation libs.lib.http.client
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+http-client = "4.0.0-SNAPSHOT"
+
+[libraries]
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }


### PR DESCRIPTION
## Summary

Migrate `lib-recaptcha` from inline dependency versions to a Gradle
TOML version catalog (`gradle/libs.versions.toml`). Part of a tree-wide
unification so bulk dep bumps (XP 8 SNAPSHOTs, etc.) can be driven from
a single sed run instead of two patterns.

The only inline-versioned dep in this repo is
`com.enonic.lib:lib-http-client`. The pin is unchanged
(`4.0.0-SNAPSHOT`); the resolved `runtimeClasspath` tree is byte-identical
to the pre-migration HEAD.

## Conventions adopted

- Version keys: lowercase, hyphen-separated (`http-client`).
- Library keys: same style, with `lib-` prefix matching the artifact name
  (`lib-http-client`).
- `[versions]` and `[libraries]` sorted alphabetically.
- `xpVersion` stays in `gradle.properties` — not moved into the catalog.
- No `[plugins]` block (no inline plugin versions in this repo worth
  cataloging — plugin versions in `build.gradle`/`settings.gradle` were
  left alone, matching the task brief).

## New catalog

```toml
[versions]
http-client = "4.0.0-SNAPSHOT"

[libraries]
lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` green locally.
- [x] `./gradlew dependencies --configuration runtimeClasspath` produces
      output byte-identical to pre-migration HEAD (only the "BUILD
      SUCCESSFUL in Xs" timing line differs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)