### PR TITLE
Simplify reCAPTCHA examples #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,137 +54,63 @@ As an example, the color scheme and size of the widget can be tuned. reCAPTCHA a
 
 ## Usage example
 
-The part "form" contains a simple usage example, which simply outputs a line of text (did it succeed or not) after submitting the form.
+Minimal reCAPTCHA **v2 checkbox** wiring for a part: render the widget on GET, verify the token on POST.
 
-### Part controller (/src/resources/parts/my-form/my-form.js)
+### Part controller (`src/main/resources/parts/my-form/my-form.js`)
 
 ```javascript
 const portal = require('/lib/xp/portal');
 const thymeleaf = require('/lib/thymeleaf');
 const recaptcha = require('/lib/recaptcha');
 
-const view = resolve('form.html');
+const view = resolve('my-form.html');
 
-// Handle GET request
-exports.get = handleGet;
-
-// Handle POST request
-exports.post = handlePost;
-
-function handleGet(req) {
-
-    function renderView() {
-        const model = createModel(req);
-
-        return {
-            body: thymeleaf.render(view, model),
-            pageContributions: {
-                headBegin: [
-                    `<script src="https://www.google.com/recaptcha/api.js?render=${recaptcha.getSiteKey()}"></script>`
-                    '<script src="http://code.jquery.com/jquery-3.4.0.min.js"></script>'
-                    ]
-            }
-        };
-    }
-
-    function createModel(req) {
-        const model = {};
-
-        model.recaptchaSiteKey = recaptcha.getSiteKey();
-        model.recaptchaIsConfigured = recaptcha.isConfigured();
-
-        // Check for live edit mode (we don't show the captcha in live edit mode)
-        model.editMode = req.mode === 'edit';
-
-        // The form post url is this component path
-        const component = portal.getComponent();
-        model.postUrl = portal.componentUrl({
-            component: component.path
-        });
-
-        return model;
-    }
-
-    return renderView();
-}
-
-function handlePost(req) {
-    // Verify the response
-    const recaptchaResponse = recaptcha.verify(req.params['token']);
-    let verify = false;
-
-    if (recaptchaResponse.success && recaptchaResponse.score > 0.5) {
-        verify = true;
-    }
-
+exports.get = function () {
+    const model = {
+        siteKey: recaptcha.getSiteKey(),
+        isConfigured: recaptcha.isConfigured(),
+        postUrl: portal.componentUrl({ component: portal.getComponent().path })
+    };
     return {
-        contentType: 'application/json',
-        body: JSON.stringify({
-            recaptchaVerified: verify
-        })
-    }
-}
+        body: thymeleaf.render(view, model),
+        pageContributions: {
+            headBegin: [
+                '<script src="https://www.google.com/recaptcha/api.js" async defer></script>'
+            ]
+        }
+    };
+};
+
+exports.post = function (req) {
+    const result = recaptcha.verify(req.params['g-recaptcha-response']);
+    return {
+        contentType: 'text/plain',
+        body: result.success ? 'Verified' : 'Failed'
+    };
+};
 ```
 
-### Part view (/src/resources/parts/my-form/my-form.html)
+### Part view (`src/main/resources/parts/my-form/my-form.html`)
 
 ```html
-<form method="POST" action="" data-th-action="${postUrl}" id="recaptchaForm">
-    <div>
-        <label>
-            <span>Name:</span>
-            <input type="text" name="name" />
-        </label>
-        <br /><br />
-        <div
-            data-th-if="${recaptchaIsConfigured and !editMode}"
-            class="g-recaptcha"
-            data-th-attr="data-sitekey=${recaptchaSiteKey}"
-            data-sitekey="124"
-            data-callback="recaptchaCallback"
-        ></div>
-        <div data-th-if="${!recaptchaIsConfigured}">
-            Please configure reCAPTCHA
-        </div>
-        <br />
-        <input type="submit" value="Submit" id="submit-button" />
-    </div>
+<form method="POST" data-th-action="${postUrl}">
+    <input type="text" name="name" />
+    <div data-th-if="${isConfigured}" class="g-recaptcha" data-th-attr="data-sitekey=${siteKey}"></div>
+    <p data-th-if="${!isConfigured}">Please configure reCAPTCHA in the site settings.</p>
+    <button type="submit">Submit</button>
 </form>
+```
 
-<div id="formResult" style="display: none;"></div>
+The reCAPTCHA script injects a hidden `g-recaptcha-response` field into the form when the user solves the
+challenge; a normal form POST then delivers it to the controller for `recaptcha.verify(...)`.
 
-<script>
-    // Enables the submit button when CAPTCHA is verified
-    function recaptchaCallback(token) {
-        var submitBtn = document.getElementById("submit-button");
-        submitBtn.removeAttribute("disabled");
-    
-        $("#recaptchaForm").submit(function (e) {
-            var postData = $(this).serializeArray();
-            // token included to the backend
-            postData.push({name: "token", value, token});
-            var formURL = $(this).attr("action");
+### reCAPTCHA v3
 
-            // Simple ajax submit with check if recaptcha verified ok or not
-            $.ajax({
-                type: "POST",
-                url: formURL,
-                data: postData,
-                success: function (data) {
-                    $("#recaptchaForm").hide();
-                    var result;
-                    if (data.recaptchaVerified) {
-                        result = "Woohooo, it worked :)";
-                    } else {
-                        result = "Oh no, try again :(";
-                    }
-                    $("#formResult").text(result).show();
-                },
-                dataType: "json",
-            });
+For [v3](https://developers.google.com/recaptcha/docs/v3) (score-based, no visible widget), load the API with
+your site key and pass the token you obtain from `grecaptcha.execute(...)` to `recaptcha.verify(token)`. The
+response includes a `score` (0.0 – 1.0) and an `action`; decide your own threshold, e.g.:
 
-            e.preventDefault();
-        });
-    };
-</script>
+```javascript
+const result = recaptcha.verify(token);
+const ok = result.success && result.score > 0.5;
 ```


### PR DESCRIPTION
## Summary

Cuts the `## Usage example` in `README.md` down to the bare minimum needed to get reCAPTCHA working, and fixes the correctness bugs that made the previous snippet unrunnable.

**Before** — one big example (part controller + view + inline script) with unrelated ballast:
- jQuery loaded over `http://`, used for ajax submit + `serializeArray` + result swapping
- Inline `formResult` div with `display: none;` cosmetics ("Woohooo, it worked :)" / "Oh no, try again :(")
- Live-edit-mode guard tangled into the widget markup
- A leftover placeholder `data-sitekey="124"` alongside the templated one

**After** — a minimal v2 checkbox flow:
- `exports.get` renders the view + loads `https://www.google.com/recaptcha/api.js` (async defer)
- `exports.post` calls `recaptcha.verify(req.params['g-recaptcha-response'])` and returns plain text
- The view is just `<form>` + `<div class="g-recaptcha">` + submit
- A short **reCAPTCHA v3** note at the bottom points at `grecaptcha.execute(...)` + `recaptcha.verify(token)` with a score threshold, for readers who need score-based verification

## Correctness bugs fixed while rewriting

The old snippet couldn't be copy-pasted; the new one can:
- Missing commas in the `pageContributions.headBegin` array (adjacent string literals silently concatenate at best, more likely a parse error).
- `postData.push({name: "token", value, token})` — malformed object literal (`value,` with no key, `token` shorthand referencing a non-existent variable).
- jQuery loaded over `http://code.jquery.com/...`.
- v2/v3 API mismatch: the example loaded the v3 script (`api.js?render=<siteKey>`) but rendered v2 markup (`<div class="g-recaptcha" data-callback="...">`). The new inline example is self-consistent v2; v3 lives in its own short subsection.

Confirmed `require('/lib/recaptcha')` is still the correct import (`src/main/resources/lib/recaptcha/index.js`).

Not touched (out of scope for this docs cleanup):
- The `## Compatibility` table (still lists up to 3.0.0; current lib is 4.x).
- The Gradle example version (`4.0.0`) and `http://repo.enonic.com/public` URL in the dependency block.
- The `site.xml` mixin snippet.

## Test plan
- [x] `README.md` renders as valid Markdown; all fenced code blocks are syntactically correct and internally consistent (single reCAPTCHA version per example).
- [x] No source under `src/` changed → no server-side E2E needed.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)