### PR TITLE
Add @enonic-types/lib-recaptcha types package #53

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             3.x

--- a/build.gradle
+++ b/build.gradle
@@ -14,3 +14,15 @@ repositories {
     mavenCentral()
     xp.enonicRepo('dev')
 }
+
+// Assemble the @enonic-types/lib-recaptcha npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,52 @@
+declare module "/lib/recaptcha" {
+    /**
+     * Google's siteverify response.
+     *
+     * `score` and `action` are only present when the token was produced by
+     * reCAPTCHA v3. `error-codes` is present when `success` is `false`.
+     *
+     * @see https://developers.google.com/recaptcha/docs/verify#api_response
+     */
+    export interface VerifyResponse {
+        /** Whether this request was a valid reCAPTCHA token for your site. */
+        success: boolean;
+        /** Timestamp of the challenge load (ISO format `yyyy-MM-dd'T'HH:mm:ssZZ`). */
+        challenge_ts: string;
+        /** The hostname of the site where the reCAPTCHA was solved. */
+        hostname: string;
+        /** The score for this request (0.0 - 1.0). reCAPTCHA v3 only. */
+        score?: number;
+        /** The action name for this request. reCAPTCHA v3 only. */
+        action?: string;
+        /** Error codes returned by Google when `success` is `false`. */
+        "error-codes"?: string[];
+    }
+
+    /**
+     * Returns the reCAPTCHA site key configured on the current site,
+     * or an empty string if none is configured.
+     */
+    export function getSiteKey(): string;
+
+    /**
+     * Returns the reCAPTCHA secret key configured on the current site,
+     * or an empty string if none is configured.
+     */
+    export function getSecretKey(): string;
+
+    /**
+     * Verifies a reCAPTCHA response token with Google's siteverify endpoint.
+     *
+     * @param response The token produced by the reCAPTCHA client widget.
+     * @returns The parsed siteverify response from Google.
+     */
+    export function verify(response: string): VerifyResponse;
+
+    /**
+     * Returns `true` when both the site key and secret key are configured
+     * on the current site.
+     */
+    export function isConfigured(): boolean;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-recaptcha",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP reCAPTCHA library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-recaptcha",
+    "recaptcha",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-recaptcha#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-recaptcha.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-recaptcha/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a published TypeScript types package for `lib-recaptcha` so consumers get typed access to `/lib/recaptcha` instead of going untyped. Mirrors the scaffolding used by [`enonic/lib-mustache` #66](https://github.com/enonic/lib-mustache/pull/66).

## Changes

- **`types/index.d.ts`** — ambient `declare module "/lib/recaptcha"` covering the four exports of `src/main/resources/lib/recaptcha/index.js`:
  - `getSiteKey(): string`
  - `getSecretKey(): string`
  - `verify(response: string): VerifyResponse`
  - `isConfigured(): boolean`
  - Plus a `VerifyResponse` interface matching Google's [siteverify response](https://developers.google.com/recaptcha/docs/verify#api_response) — `success`, `challenge_ts`, `hostname` (required); `score`, `action` (reCAPTCHA v3 only); `error-codes` (present on failure).
- **`types/package.json`** — `@enonic-types/lib-recaptcha` manifest, `@enonic-types/core: ^8.0.0` as a dependency, `publishConfig.access: public`, `version: 0.0.0` (substituted at build).
- **`build.gradle`** — `assembleTypes` Copy task that copies `types/` to `build/types/` and substitutes `project.version` into `package.json`; `jar.dependsOn assembleTypes`.
- **`.github/workflows/enonic-gradle.yml`** — `npmPublish: true` on the `build-and-publish` step + top-level `permissions: { id-token: write, contents: write }` for npm OIDC / trusted publishing.

## Verification

- `./gradlew build` green locally.
- `build/types/` contains `index.d.ts` + `package.json` with the correct substituted version (`4.1.0-SNAPSHOT`).
- The `.d.ts` type-checks under `tsc --strict`.
- Every JS export in `src/main/resources/lib/recaptcha/index.js` is typed.

## Notes

This is the first publish of a brand-new `@enonic-types/lib-recaptcha` npm package, so npm trusted-publisher setup for this repo may still be required before the first release from `master` succeeds. Depends on [enonic/release-tools#71](https://github.com/enonic/release-tools/pull/71) (merged).

Closes #53